### PR TITLE
Added proposed enhnacemnts for Number Range.

### DIFF
--- a/Specs/Number/Arabic/NumberRangeModel.json
+++ b/Specs/Number/Arabic/NumberRangeModel.json
@@ -1032,17 +1032,7 @@
     "Input": "الرقم هو ٢٠٠ الى ٣٠٠ في ٢٠٠٨",
     "NotSupportedByDesign": "java, javascript, python",
     "NotSupported": "dotnet",
-    "Results": [
-      {
-        "Text": "",
-        "TypeName": "",
-        "Resolution": {
-          "value": ""
-        },
-        "Start": 0,
-        "End": -1
-      }
-    ]
+    "Results": []
   },
   {
     "Input": "الرقم هو من ٢٠٠ الى ٣٠٠٠٠٠٠ في ٢٠١٨",
@@ -1288,6 +1278,366 @@
         },
         "Start": 23,
         "End": 43
+      }
+    ]
+  },
+  {
+    "Input": "وهو يحتل مرتبة أعلى من العاشر ولكنه أقل من الخامس عشر.",
+    "NotSupportedByDesign": "java, javascript, python",
+    "NotSupported": "dotnet",
+    "Results": [
+      {
+        "Text": "أعلى من العاشر ولكنه أقل من الخامس عشر",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(10,15)"
+        },
+        "Start": 15,
+        "End": 52
+      }
+    ]
+  },
+  {
+    "Input": "هذا الرقم هو أعلى أو يساوي مائة أو أقل أو يساوي ثلاثمائة",
+    "NotSupportedByDesign": "java, javascript, python",
+    "NotSupported": "dotnet",
+    "Results": [
+      {
+        "Text": "أعلى أو يساوي مائة أو أقل أو يساوي ثلاثمائة",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "[100,300]"
+        },
+        "Start": 13,
+        "End": 55
+      }
+    ]
+  },
+  {
+    "Input": "نطاق الرقم من ٢٠  إلى ١٠٠ ",
+    "NotSupportedByDesign": "java, javascript, python",
+    "NotSupported": "dotnet",
+    "Results": [
+      {
+        "Text": "من ٢٠  إلى ١٠٠ ",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "[20,100)"
+        },
+        "Start": 11,
+        "End": 24
+      }
+    ]
+  },
+  {
+    "Input": "وهو أكثر من ثلاثين سنة من عمره ",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "أكثر من ثلاثين",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(30,)"
+        },
+        "Start": 4,
+        "End": 17
+      }
+    ]
+  },
+  {
+    "Input": "يوجد حوالي خمسمائة أو أكثر في هذه المنتجات.",
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "خمسمائة أو أكثر",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "[500,)"
+        },
+        "Start": 11,
+        "End": 25
+      }
+    ]
+  },
+  {
+    "Input": "ارتفاعه أقل من ١٧٠ ",
+    "NotSupportedByDesign": "java, javascript, python",
+    "NotSupported": "dotnet",
+    "Results": [
+      {
+        "Text": "أقل من ١٧٠ ",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(,170)"
+        },
+        "Start": 8,
+        "End": 17
+      }
+    ]
+  },
+  {
+    "Input": "درجته ٢٠٠  أو أكبر",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "٢٠٠  أو أكبر",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "[200,)"
+        },
+        "Start": 6,
+        "End": 17
+      }
+    ]
+  },
+  {
+    "Input": "درجته أقل من ٣٠  او ما يعادله",
+    "NotSupportedByDesign": "java, javascript, python",
+    "NotSupported": "dotnet",
+    "Results": [
+      {
+        "Text": "أقل من ٣٠  او ما يعادله",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(,30]"
+        },
+        "Start": 6,
+        "End": 28
+      }
+    ]
+  },
+  {
+    "Input": "درجته تساوي ٣٠  أو ما تقل عنه ",
+    "NotSupportedByDesign": "java, javascript, python",
+    "NotSupported": "dotnet",
+    "Results": [
+      {
+        "Text": "٣٠  أو ما تقل",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(,30]"
+        },
+        "Start": 12,
+        "End": 24
+      }
+    ]
+  },
+  {
+    "Input": "درجته ٣٠  على الأقل أو ما يعادله ",
+    "NotSupportedByDesign": "java, javascript, python",
+    "NotSupported": "dotnet",
+    "Results": [
+      {
+        "Text": "٣٠  على الأقل أو ما يعادله ",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "[30,)"
+        },
+        "Start": 6,
+        "End": 31
+      }
+    ]
+  },
+  {
+    "Input": "درجته تساوي ٣٠  أو اكثر منه",
+    "NotSupportedByDesign": "java, javascript, python",
+    "NotSupported": "dotnet",
+    "Results": [
+      {
+        "Text": "تساوي ٣٠  أو اكثر",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "[30,)"
+        },
+        "Start": 6,
+        "End": 22
+      }
+    ]
+  },
+  {
+    "Input": "درجته تساوي ٥٠٠٠  أو أقل منه ",
+    "NotSupportedByDesign": "java, javascript, python",
+    "NotSupported": "dotnet",
+    "Results": [
+      {
+        "Text": " تساوي ٥٠٠٠  أو أقل",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(,5000]"
+        },
+        "Start": 6,
+        "End": 23
+      }
+    ]
+  },
+  {
+    "Input": "درجته تساوي ٥٠٠٠  أو اكثر منه",
+    "NotSupportedByDesign": "java, javascript, python",
+    "NotSupported": "dotnet",
+    "Results": [
+      {
+        "Text": "تساوي ٥٠٠٠  أو اكثر",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "[5000,)"
+        },
+        "Start": 6,
+        "End": 24
+      }
+    ]
+  },
+  {
+    "Input": "درجته تساوي ٥٠٠٠  أو اكثر من ٤٥٠٠ ",
+    "NotSupportedByDesign": "java, javascript, python",
+    "NotSupported": "dotnet",
+    "Results": [
+      {
+        "Text": "تساوي ٥٠٠٠",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "[5000,5000]"
+        },
+        "Start": 6,
+        "End": 15
+      },
+      {
+        "Text": "اكثر من ٤٥٠٠",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(4500,)"
+        },
+        "Start": 21,
+        "End": 32
+      }
+    ]
+  },
+  {
+    "Input": "درجته اكثر من ٥٠٠٠  أو ما يعادل من",
+    "NotSupportedByDesign": "java, javascript, python",
+    "NotSupported": "dotnet",
+    "Results": [
+      {
+        "Text": "اكثر من ٥٠٠٠  أو ما يعادل",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "[5000,)"
+        },
+        "Start": 6,
+        "End": 30
+      }
+    ]
+  },
+  {
+    "Input": "درجته اكثر من ٥٠٠٠  أو ما يعادله ",
+    "NotSupportedByDesign": "java, javascript, python",
+    "NotSupported": "dotnet",
+    "Results": [
+      {
+        "Text": "اكثر من ٥٠٠٠  أو ما يعادل",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "[5000,)"
+        },
+        "Start": 6,
+        "End": 30
+      }
+    ]
+  },
+  {
+    "Input": "ماذا عن ٢  في ٥  أو أكثر",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "٢  في ٥  أو أكثر",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "[0.4,)"
+        },
+        "Start": 8,
+        "End": 23
+      }
+    ]
+  },
+  {
+    "Input": "ماذا عن أكثر من ٢  في ٥ ",
+    "NotSupportedByDesign": "java, javascript, python",
+    "NotSupported": "dotnet",
+    "Results": [
+      {
+        "Text": "أكثر من ٢ ",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(2,)"
+        },
+        "Start": 8,
+        "End": 16
+      }
+    ]
+  },
+  {
+    "Input": "هل يمكنك أن تعرضني سجلات أكثر من ٣٠٠٠٠  في عام ٢٠٠٩م",
+    "NotSupportedByDesign": "java, javascript, python",
+    "NotSupported": "dotnet",
+    "Results": [
+      {
+        "Text": "أكثر من ٣٠٠٠٠ ",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(30000,)"
+        },
+        "Start": 25,
+        "End": 37
+      }
+    ]
+  },
+  {
+    "Input": "هل يمكنك أن تعرضني سجلات أقل من ٣٠٠٠٠  في عام ٢٠٠٩م ",
+    "NotSupportedByDesign": "java, javascript, python",
+    "NotSupported": "dotnet",
+    "Results": [
+      {
+        "Text": "أقل من ٣٠٠٠٠ ",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(,3000)"
+        },
+        "Start": 25,
+        "End": 36
+      }
+    ]
+  },
+  {
+    "Input": "العدد يساوي ٢٠٠٠٠  في ١٩٩٨م",
+    "NotSupportedByDesign": "java, javascript, python",
+    "NotSupported": "dotnet",
+    "Results": [
+      {
+        "Text": "يساوي ٢٠٠٠٠  في ١٩٩٨م",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "[10.01001001001,10.01001001001]"
+        },
+        "Start": 6,
+        "End": 26
+      }
+    ]
+  },
+  {
+    "Input": "هو تجاوز ٣٠٠٠  سجل هذا العام",
+    "NotSupportedByDesign": "java, javascript, python",
+    "NotSupported": "dotnet",
+    "Results": [
+      {
+        "Text": " تجاوز ٣٠٠٠ ",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(3000,)"
+        },
+        "Start": 3,
+        "End": 12
       }
     ]
   },


### PR DESCRIPTION
**PR Includes**
•	Specs
               Number-Range Model - Proposed Enhancements

•	Proposed Enhancement  22 : Extractor Passed - 4, Full Passed - 1, Skipped - 18
•	Total Test Cases 167: Extractor Passed - 109, Full Passed - 49, Skipped - 58
              New Cases 100: Extractor Passed - 68, Full Passed - 13, Skipped- 32
              Existing Cases 67: Extractor Passed - 41, Full Passed - 36, Skipped - 26
              

One of the cases from earlier iteration had incorrect result set which is updated in this PR.
Changes to input: "الرقم هو ٢٠٠ الى ٣٠٠ في ٢٠٠٨", - resolution set.

Checklist:
•   Verified inputs from Linguist 
•   Verified for consistency of similar cases given by linguist 
•   Categorized the test spec 
•   No duplicate inputs 
•   Verified indexes 
•   Executed the ./build.cmd in VS Code for duplication 
•   Updated daily status tracker in teams 
•   Uploaded the JSON and excel sheets in Teams folder
