### PR TITLE
Created new regex NumbersWithSpace and Fixed numbers with spaces in between

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Arabic/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Arabic/NumbersDefinitions.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Recognizers.Definitions.Arabic
       public static readonly string AllIntRegex = $@"(?:({SeparaIntRegex})((\s+(و)?)({SeparaIntRegex})(\s+{RoundNumberIntegerRegex})?)*|((({TenToNineteenIntegerRegex}|({TensNumberIntegerRegex}(\s+(و)?|\s*-\s*){ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex})?(\s+{RoundNumberIntegerRegex})+)\s+(و)?)*{SeparaIntRegex})";
       public const string PlaceHolderPureNumber = @"\b";
       public const string PlaceHolderDefault = @"\D|\b";
+      public static readonly Func<string, string> NumbersWithSpace = (placeholder) => $@"((((?<!\d+\s*)-\s*)|((?<=\b)(?<!(\d+\.|\d+,))))(\d{{1,3}})(((\s)+(\d{{1,3}})))+)(?={placeholder})";
       public static readonly Func<string, string> NumbersWithPlaceHolder = (placeholder) => $@"(((?<!\d+\s*)([-]\s*)?)|(?<=\b))\d+(?!([\.،,]\d+[\u0621-\u064A]))(?={placeholder})";
       public static readonly string NumbersWithSuffix = $@"(((?<!\d+\s*)([-]\s*)?)|(?<=\b))\d+\s*{BaseNumbers.NumberMultiplierRegex}(?=\b)";
       public static readonly string RoundNumberIntegerRegexWithLocks = $@"(?<=\b)(\d+\s*({RoundNumberIntegerRegex})(\s|و\s|\sو))?\d+(\s|و\s|\sو)+{RoundNumberIntegerRegex}((\s*و\s*)+\d+)?(?=\b)";

--- a/.NET/Microsoft.Recognizers.Text.Number/Arabic/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Arabic/Extractors/IntegerExtractor.cs
@@ -29,6 +29,10 @@ namespace Microsoft.Recognizers.Text.Number.Arabic
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
+                    new Regex(NumbersDefinitions.NumbersWithSpace(config.Placeholder), RegexFlags),
+                    RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
+                },
+                {
                     new Regex(NumbersDefinitions.NumbersWithSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },

--- a/Patterns/Arabic/Arabic-Numbers.yaml
+++ b/Patterns/Arabic/Arabic-Numbers.yaml
@@ -46,6 +46,9 @@ PlaceHolderPureNumber: !simpleRegex
   def: \b
 PlaceHolderDefault: !simpleRegex
   def: \D|\b
+NumbersWithSpace: !paramsRegex
+  def: ((((?<!\d+\s*)-\s*)|((?<=\b)(?<!(\d+\.|\d+,))))(\d{1,3})(((\s)+(\d{1,3})))+)(?={placeholder})
+  params: [placeholder]
 NumbersWithPlaceHolder: !paramsRegex
   def: (((?<!\d+\s*)([-]\s*)?)|(?<=\b))\d+(?!([\.،,]\d+[\u0621-\u064A]))(?={placeholder})
   params: [placeholder]

--- a/Specs/Number/Arabic/NumberModel.json
+++ b/Specs/Number/Arabic/NumberModel.json
@@ -2339,8 +2339,8 @@
   },
   {
     "Input": "٠٠٠ ٤٠ هو نفسه ٠٠٠ ٤٠",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "٠٠٠ ٤٠",
@@ -2366,8 +2366,8 @@
   },
   {
     "Input": "في الوقت الحالي ، يبلغ عدد سكان الصين  ١٠٠ ٠٢١ ٤١٤ ١",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "١٠٠ ٠٢١ ٤١٤ ١",


### PR DESCRIPTION
This PR contains:

1. Fix for inputs في الوقت الحالي ، يبلغ عدد سكان الصين  ١٠٠ ٠٢١ ٤١٤ ١ and ٠٠٠ ٤٠ هو نفسه ٠٠٠ ٤٠
2. A new regex created called NumbersWithSpace in Arabic.yaml file
3. The new regex is added into NumberDefination.cs file to avoid Build error.
4. The new regex is added to IntegerExtractor.cs file.
5. The NumberModel.json file with the attributes "IgnoreResolution": true and  "NotSupported": dotnet", removed.

| Langauge | ModelType | Result | Count
| -- | -- | -- | --
  ARABIC | NumberModel | ExtractorPass | 276
  ARABIC | NumberModel | FullPass | 125
  ARABIC | NumberModel | Skipped | 43



Self Review CheckList:
- [x] No build error?

- [x] Ran all test cases?

- [x] All cases getting passed?

- [x] Followed re-usability?

- [x] Followed the naming conventions?

- [x] New change does not negatively impact on performance?

- [x] Is the code readable?

- [x] Following the best practices?