### PR TITLE
Fixed Existing NumberRange cases for three inputs

### DIFF
--- a/Patterns/Arabic/Arabic-Numbers.yaml
+++ b/Patterns/Arabic/Arabic-Numbers.yaml
@@ -177,9 +177,9 @@ TillRegex: !simpleRegex
 MoreRegex: !simpleRegex
   def: (?:(اكثر|فوق|أكبر|أعظم|أطول|يتجاوز|تفوق|أعلى|أكثر)|(?<!<|=)>)
 LessRegex: !simpleRegex
-  def: (?:(أقل|اقل|اصغر|أصغر|أخفض|ادنى)(\s*من)?|تحت|(?<!>|=)<)
+  def: (?:(أقل|اقل|اصغر|أصغر|أخفض|ادنى|يصل إلى)(\s*من)?|تحت|(?<!>|=)<)
 EqualRegex: !simpleRegex
-  def: (يساوي|(?<!<|>)=)
+  def: (يساوي|تساوي| تساوي|(?<!<|>)=)
 MoreOrEqualPrefix: !nestedRegex
   def: (((ليس|لا)\s+{LessRegex})|(على\s+الأقل))
   references: [LessRegex]
@@ -205,7 +205,7 @@ LessRegexNoNumberSucceed: !simpleRegex
 EqualRegexNoNumberSucceed: !simpleRegex
   def: ((يساوي)(?!(\s*\d+)))
 OneNumberRangeMoreRegex1: !nestedRegex
-  def: ({MoreOrEqual})\s*(ال)?(?<number1>({NumberSplitMark}.)+)|({EqualRegex}\s*(أو|او)?\s+({MoreRegex}))(\s+(من))\s*(?<number1>({NumberSplitMark}.)+)|({EqualRegex}\s+(أو|او)?\s+({MoreRegex}))\s*(?<number1>({NumberSplitMark}.)+)|({MoreRegex})(\s+(من))\s*(?<number1>({NumberSplitMark}.)+)|({MoreRegex})\s*(?<number1>({NumberSplitMark}.)+)
+  def: ({MoreOrEqual})\s*(ال)?(?<number1>({NumberSplitMark}.)+)|({EqualRegex}\s*(أو|او)?\s+({MoreRegex}))(\s+(من))\s*(?<number1>({NumberSplitMark}.)+)|(({EqualRegex})\s+(?<number1>({NumberSplitMark}.)+)(أو|او)?\s+({MoreRegex})(\s+(من))?)|({EqualRegex}\s+(أو|او)?\s+({MoreRegex}))\s*(?<number1>({NumberSplitMark}.)+)|({MoreRegex})(\s+(من))\s*(?<number1>({NumberSplitMark}.)+)|({MoreRegex})\s*(?<number1>({NumberSplitMark}.)+)
   references: [MoreOrEqual, MoreRegex, NumberSplitMark,EqualRegex]
 OneNumberRangeMoreRegex3: !nestedRegex
   def: (?<number1>({NumberSplitMark}.)+)\s*(و|أو)\s*({MoreRegex})

--- a/Specs/Number/Arabic/NumberRangeModel.json
+++ b/Specs/Number/Arabic/NumberRangeModel.json
@@ -716,8 +716,8 @@
   },
   {
     "Input": "يساوي ٥٠٠٠ او اكثر من",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
+    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "يساوي ٥٠٠٠ او اكثر من",
@@ -2280,8 +2280,7 @@
   },
   {
     "Input": "نقاطه تساوي 5000 أو أقل",
-    "Comment": "PendingValidation",
-    "NotSupported": "javascript, python, dotnet",
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "تساوي 5000 أو أقل",
@@ -2290,8 +2289,8 @@
           "value": "(,5000]",
           "score": 0.0
         },
-        "Start": -1,
-        "End": -1
+        "Start": 6,
+        "End": 22
       }
     ]
   },
@@ -2429,8 +2428,7 @@
   },
   {
     "Input": "نقاطه تساوي 5000 أو أقل من 5000",
-    "Comment": "PendingValidation",
-    "NotSupported": "javascript, python, dotnet",
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "تساوي 5000",
@@ -2439,8 +2437,8 @@
           "value": "[5000,5000]",
           "score": 0.0
         },
-        "Start": -1,
-        "End": -1
+        "Start": 6,
+        "End": 15
       },
       {
         "Text": "أقل من 5000",
@@ -2719,8 +2717,7 @@
   },
   {
     "Input": "تخطط شركة نيسان موتور لخفض ما يصل إلى 700 عامل متعاقد.",
-    "Comment": "PendingValidation",
-    "NotSupported": "javascript, python, dotnet",
+    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "يصل إلى 700",
@@ -2729,8 +2726,8 @@
           "value": "(,700]",
           "score": 0.0
         },
-        "Start": -1,
-        "End": -1
+        "Start": 30,
+        "End": 40
       }
     ]
   },


### PR DESCRIPTION
This PR contains the Fix for inputs:
تخطط شركة نيسان موتور لخفض ما يصل إلى 700 عامل متعاقد.
نقاطه تساوي 5000 أو أقل من 5000
نقاطه تساوي 5000 أو أكثر

Added 2 variation for 'Equals' in EqualRegex.
Added a variation of 'up to' in LessRegex.
Modified OneNumberRangeMoreRegex1, to incorporate cases like equal to 'number' or more. Previously, this regex only handled only cases like equal or more 'number'.
Modified the spec to remove "NotSupported:dotnet" attribute and fixed start and end.
Latest count for All cases in NumberRange:


  | ARABIC | NumberRangeModel | FullPass | 50
-- | -- | -- | -- | --
  | ARABIC | NumberRangeModel | ExtractorPass | 106
  | ARABIC | NumberRangeModel | Skipped | 39


Latest Count for only Existing cases in NumberRange:

 	

  | ARABIC | NumberRangeModel | FullPass | 30
-- | -- | -- | -- | --
  | ARABIC | NumberRangeModel | Skipped | 14
  | ARABIC | NumberRangeModel | ExtractorPass | 31


Self Review Check list:

 
- [x] No duplicate codes?

- [x] No build error?

- [x] Ran all test cases?

- [x] All cases getting passed?

- [x] Followed reusability?

- [x] Followed the naming conventions?

- [x] New change does not negatively impact on performance?

- [x] Is the code readable?

- [x] Following the best practices?