### PR TITLE
Fixed 6 issues in AR number model existing

### DIFF
--- a/Patterns/Arabic/Arabic-Numbers.yaml
+++ b/Patterns/Arabic/Arabic-Numbers.yaml
@@ -33,7 +33,7 @@ SeparaIntRegex: !nestedRegex
       RoundNumberIntegerRegex
     ]
 AllIntRegex: !nestedRegex
-  def: (?:({SeparaIntRegex})((\s+(و)?)({SeparaIntRegex})(\s+{RoundNumberIntegerRegex})?)*|((({TenToNineteenIntegerRegex}|({TensNumberIntegerRegex}(\s+(و)?|\s*-\s*){ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex})?(\s+{RoundNumberIntegerRegex})+)\s+(و)?)*{SeparaIntRegex})
+  def: (?:({SeparaIntRegex})((\s+(و)?(\s+)?)({SeparaIntRegex})(\s+{RoundNumberIntegerRegex})?)*|((({TenToNineteenIntegerRegex}|({TensNumberIntegerRegex}(\s+(و)?|\s*-\s*){ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex})?(\s+{RoundNumberIntegerRegex})+)\s+(و)?)*{SeparaIntRegex})
   references:
     [
       TenToNineteenIntegerRegex,
@@ -645,5 +645,7 @@ RelativeReferenceRelativeToMap: !dictionary
     الثانية الى الاخير: end
     السابق: current    
 ...
+
+
 
 

--- a/Specs/Number/Arabic/NumberModel.json
+++ b/Specs/Number/Arabic/NumberModel.json
@@ -1661,12 +1661,13 @@
   {
     "Input": "هذاك جيد حقا.",
     "NotSupportedByDesign": "javascript, java, python",
+    "NotSupported": "dotnet",
     "Results": []
   },
   {
     "Input": "في بعض البلدان تستطيع ان تكتب ٥.٠٠ او ٥,٠٠",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
+    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "٥.٠٠",
@@ -3338,7 +3339,6 @@
     "Input": "مائة و ستة عشر",
     "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "مائة و ستة عشر",
@@ -3822,7 +3822,6 @@
     "Input": "مائتان و اثنان ألف",
     "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "مائتان و اثنان ألف",
@@ -4591,9 +4590,9 @@
   },
   {
     "Input": "مائة و اثنان و ثلاثون خمس",
+    "IgnoreResolution": true,
     "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "مائة و اثنان و ثلاثون خمس",
@@ -4647,7 +4646,6 @@
     "Input": "واحد من مائة و خمسة",
     "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "واحد من مائة و خمسة",
@@ -4665,7 +4663,6 @@
     "Input": "مائة من ألف و خمسة",
     "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "مائة من ألف و خمسة",
@@ -4836,7 +4833,6 @@
     "Input": "واحد على مائة و خمسة و عشرون",
     "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "واحد على مائة و خمسة و عشرون",


### PR DESCRIPTION
Fixed 6 issues in Number model existing specs 

Regex: AllIntRegex

Cases:

1. مائة و ستة عشر
2. مائتان و اثنان ألف
3. مائة و اثنان و ثلاثون خمس
4. واحد من مائة و خمسة
5.مائة من ألف و خمسة
6. واحد على مائة و خمسة و عشرون

ARABIC | NumberModel | ExtractorPass | 300
ARABIC | NumberModel | FullPass | 139
ARABIC | NumberModel | Skipped | 19

- [x] No duplicate codes? 

- [x] No build error? 

- [x] Ran all test cases? 

- [x] All cases getting passed? 

- [x] Followed reusability? 

- [x] Followed the naming conventions? 

- [x] New change does not negatively impact on performance? 

- [x] Is the code readable? 

- [x] Following the best practices? 
