### PR TITLE
Added a variation of 'Exceed' in MoreRegex

### DIFF
--- a/Patterns/Arabic/Arabic-Numbers.yaml
+++ b/Patterns/Arabic/Arabic-Numbers.yaml
@@ -175,7 +175,7 @@ NumberWithPrepositionPercentage: !nestedRegex
 TillRegex: !simpleRegex
   def: (الى|إلى|خلال|--|-|—|——|~|–)
 MoreRegex: !simpleRegex
-  def: (?:(اكثر|فوق|أكبر|أعظم|أطول|يتجاوز|تفوق|أعلى|أكثر|على الأقل)|(?<!<|=)>)
+  def: (?:(اكثر|فوق|أكبر|أعظم|أطول|تجاوز|يتجاوز|تفوق|أعلى|أكثر|على الأقل)|(?<!<|=)>)
 LessRegex: !simpleRegex
   def: (?:(على الأكثر|أقل|اقل|اصغر|أصغر|أخفض|ادنى|يصل إلى)(\s*من)?|تحت|(?<!>|=)<)
 EqualRegex: !simpleRegex
@@ -648,6 +648,3 @@ RelativeReferenceRelativeToMap: !dictionary
     الثانية الى الاخير: end
     السابق: current    
 ...
-
-
-

--- a/Specs/Number/Arabic/NumberRangeModel.json
+++ b/Specs/Number/Arabic/NumberRangeModel.json
@@ -1623,8 +1623,8 @@
   },
   {
     "Input": "هو تجاوز ٣٠٠٠ سجل هذا العام",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "تجاوز ٣٠٠٠",


### PR DESCRIPTION
This PR contains:
Fix for Input 'هو تجاوز ٣٠٠٠ سجل هذا العام'
Added a variation for 'exceed' in MoreRegex.

Latest count for NumberRange:

  | ARABIC | NumberRangeModel | FullPass | 66
-- | -- | -- | -- | --
  | ARABIC | NumberRangeModel | ExtractorPass | 140
  | ARABIC | NumberRangeModel | Skipped | 27



Self Review checkList:

- [x] No build error?

- [x] Ran all test cases?

- [x] All cases getting passed?

- [x] Followed reusability?

- [x] Followed the naming conventions?

- [x] New change does not negatively impact on performance?

- [x] Is the code readable?

- [x] Following the best practices?
